### PR TITLE
Fix typo in `scheduler.CancellationToken` docstring

### DIFF
--- a/src/async_utils/scheduler.py
+++ b/src/async_utils/scheduler.py
@@ -26,7 +26,7 @@ __all__ = ("CancellationToken", "Scheduler")
 
 
 class CancellationToken:
-    """An object to use for cancelation of a task.
+    """An object to use for cancellation of a task.
 
     Not meant for public construction.
     """


### PR DESCRIPTION
## Description of Changes

While the class is called `CancellationToken`, the docstring has the word 'cancelation'. I assume it's meant to be 'cancellation'.
